### PR TITLE
update:shipping_addresses

### DIFF
--- a/app/controllers/end_user/shipping_addresses_controller.rb
+++ b/app/controllers/end_user/shipping_addresses_controller.rb
@@ -3,6 +3,18 @@ class EndUser::ShippingAddressesController < ApplicationController
   	@shipping_address = ShippingAddress.new
   end
 
+  def create
+  	@shipping_address = ShippingAddress.new(shipping_address_params)
+  	@shipping_address.customer_id = current_customer.id
+  	@shipping_address.save
+  	redirect_to request.referer
+  end
+
   def edit
+  end
+
+  private
+  def shipping_address_params
+  	params.require(:shipping_address).permit(:postcode, :address, :destination)
   end
 end

--- a/app/views/end_user/shipping_addresses/index.html.erb
+++ b/app/views/end_user/shipping_addresses/index.html.erb
@@ -15,6 +15,8 @@
 		    <div class="col-md-offset-1 col-md-11">
 		        <%= f.label :destination, "宛先" %>
 		        <%= f.text_field :destination %>
+
+		        <%= f.submit '登録する', class: 'btn btn-success' %>
 		    </div>
 		    <% end %>
 		</div>

--- a/db/migrate/20200820080343_rename_customer_column_to_shipping_addresses.rb
+++ b/db/migrate/20200820080343_rename_customer_column_to_shipping_addresses.rb
@@ -1,0 +1,5 @@
+class RenameCustomerColumnToShippingAddresses < ActiveRecord::Migration[5.2]
+  def change
+  	rename_column :shipping_addresses, :customer, :customer_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_19_074703) do
+ActiveRecord::Schema.define(version: 2020_08_20_080343) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -92,7 +92,7 @@ ActiveRecord::Schema.define(version: 2020_08_19_074703) do
   end
 
   create_table "shipping_addresses", force: :cascade do |t|
-    t.integer "customer", null: false
+    t.integer "customer_id", null: false
     t.string "postcode", null: false
     t.string "address", null: false
     t.string "destination", null: false


### PR DESCRIPTION
## shipping_addressesのページに住所登録機能を追加しました。
- controllerにcreateアクション追加 追記
- shipping_addressのカラム名が間違っていた為、customer　→　customer_id　変更